### PR TITLE
Show Clerk login before app init

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,9 +32,9 @@ function App() {
 }
 
 function AppContent() {
-  const { vpnStatus } = useVPN();
   const [user, setUser] = useState<any>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const { vpnStatus } = useVPN(isAuthenticated, user?.accessLevel);
   
   // Make debug functions available globally for testing
   useEffect(() => {

--- a/src/components/auth/ClerkLoginForm.tsx
+++ b/src/components/auth/ClerkLoginForm.tsx
@@ -6,8 +6,6 @@ import { Separator } from '../ui/separator';
 import { LoadingScreen } from '../ui/loading-screen';
 import { ErrorDisplay } from '../ui/error-display';
 import clerkAuth from '../../services/clerkService';
-import { SecureBrowserDatabaseService } from '../../services/databaseService';
-import { initSupabaseClient } from '@/lib/supabase';
 import type { AuthState } from '../../types/clerk';
 import { Shield, Users, Lock, Chrome, Globe } from 'lucide-react';
 
@@ -106,10 +104,6 @@ export const ClerkLoginForm: React.FC<ClerkLoginFormProps> = ({
     }
   };
 
-  if (isInitializing) {
-    return <LoadingScreen stage="auth" message="Initializing secure authentication..." progress={50} />;
-  }
-
   if (initError) {
     return (
       <ErrorDisplay
@@ -205,10 +199,15 @@ export const ClerkLoginForm: React.FC<ClerkLoginFormProps> = ({
             {/* Sign In Button */}
             <Button
               onClick={handleSignIn}
-              disabled={isSigningIn || isSigningUp}
+              disabled={isSigningIn || isSigningUp || isInitializing}
               className="w-full h-12 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-all duration-200 shadow-md hover:shadow-lg disabled:opacity-50"
             >
-              {isSigningIn ? (
+              {isInitializing ? (
+                <div className="flex items-center gap-2">
+                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  Loading...
+                </div>
+              ) : isSigningIn ? (
                 <div className="flex items-center gap-2">
                   <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
                   Signing in...
@@ -226,11 +225,16 @@ export const ClerkLoginForm: React.FC<ClerkLoginFormProps> = ({
             {/* Sign Up Button */}
             <Button
               onClick={handleSignUp}
-              disabled={isSigningIn || isSigningUp}
+              disabled={isSigningIn || isSigningUp || isInitializing}
               variant="outline"
               className="w-full h-12 border-gray-300 text-gray-700 font-medium rounded-lg transition-all duration-200 hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50"
             >
-              {isSigningUp ? (
+              {isInitializing ? (
+                <div className="flex items-center gap-2">
+                  <div className="w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+                  Loading...
+                </div>
+              ) : isSigningUp ? (
                 <div className="flex items-center gap-2">
                   <div className="w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
                   Creating account...

--- a/src/hooks/useVPN.ts
+++ b/src/hooks/useVPN.ts
@@ -96,7 +96,7 @@ const checkIPGeolocation = async (): Promise<{ country: string; ip: string; isAu
   }
 };
 
-export const useVPN = (userAccessLevel?: number) => {
+export const useVPN = (enabled = true, userAccessLevel?: number) => {
   const [vpnStatus, setVpnStatus] = useState<VPNStatus>("disconnected");
   const [connection, setConnection] = useState<VPNConnection>({
     endpoint: "au-sydney-01.vpn.provider.com",
@@ -267,6 +267,8 @@ export const useVPN = (userAccessLevel?: number) => {
 
   // Fast initial VPN check on mount
   useEffect(() => {
+    if (!enabled) return;
+
     let mounted = true;
 
     const checkInitialStatus = async () => {
@@ -350,19 +352,21 @@ export const useVPN = (userAccessLevel?: number) => {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [enabled]);
 
   // Periodic VPN status check - reduced frequency to minimize system load
   useEffect(() => {
+    if (!enabled) return;
     const interval = setInterval(() => {
       checkVPNStatus();
     }, 60000); // Check every 60 seconds (reduced from 15s to prevent API spam)
 
     return () => clearInterval(interval);
-  }, [checkVPNStatus]);
+  }, [enabled, checkVPNStatus]);
 
   // Auto-reconnect logic - triggered when status changes to disconnected
   useEffect(() => {
+    if (!enabled) return;
     if (vpnStatus === "disconnected") {
       const autoReconnectTimeout = setTimeout(() => {
         // Check current state and attempt reconnect if conditions are met
@@ -379,7 +383,7 @@ export const useVPN = (userAccessLevel?: number) => {
 
       return () => clearTimeout(autoReconnectTimeout);
     }
-  }, [vpnStatus]); // Only depend on vpnStatus
+  }, [enabled, vpnStatus]); // Only depend on vpnStatus
 
   return {
     vpnStatus,


### PR DESCRIPTION
## Summary
- Delay VPN hooks until after Clerk authentication using an enabled flag
- Render Clerk login form immediately and disable buttons while auth loads
- Use login state to trigger VPN monitoring only once signed in
